### PR TITLE
Import config from new location

### DIFF
--- a/experiments/configs/profiled_runs.py
+++ b/experiments/configs/profiled_runs.py
@@ -22,14 +22,11 @@ from .graph_experiments import (
     feature_pred_tests,
     five_lm_feature_matching,
 )
+from .more_pretraining_experiments import supervised_pre_training_storeall
 
 randrot_noise_10distinctobj_5lms_dist_agent = import_config_from_monty(
     "ycb_experiments.py",
     "randrot_noise_10distinctobj_5lms_dist_agent",
-)
-
-supervised_pre_training_storeall = import_config_from_monty(
-    "pretraining_experiments.py", "supervised_pre_training_storeall"
 )
 
 


### PR DESCRIPTION
This is a fix for the issue reported [here](https://github.com/thousandbrainsproject/monty_lab/issues/1). A config was being imported from the wrong location. This is a very small fix that gets `monty_lab/experiments/run.py` running without errors.