### PR TITLE
`view_finder_images`: Create images of objects that fit within the viewfinder's field-of-view

### DIFF
--- a/experiments/configs/__init__.py
+++ b/experiments/configs/__init__.py
@@ -15,10 +15,10 @@ from .evidence_sdr_evaluation import CONFIGS as EVIDENCESDREVAL
 from .feature_matching_evaluation import CONFIGS as FEATUREEVAL
 from .follow_ups import CONFIGS as FOLLOW_UPS
 from .graph_experiments import CONFIGS as GRAPHS
-from .images_for_vit import CONFIGS as IMAGES_FOR_VIT
 from .policy_experiments import CONFIGS as POLICYEVAL
 from .profiled_runs import CONFIGS as PROFILED_RUNS
 from .robustness_experiments import CONFIGS as ROBUSTNESSEVAL
+from .view_finder_images import CONFIGS as VIEW_FINDER_IMAGES
 
 CONFIGS = dict()
 CONFIGS.update(BASE)
@@ -31,4 +31,4 @@ CONFIGS.update(EVIDENCESDREVAL)
 CONFIGS.update(POLICYEVAL)
 CONFIGS.update(ROBUSTNESSEVAL)
 CONFIGS.update(FOLLOW_UPS)
-CONFIGS.update(IMAGES_FOR_VIT)
+CONFIGS.update(VIEW_FINDER_IMAGES)

--- a/experiments/configs/view_finder_images.py
+++ b/experiments/configs/view_finder_images.py
@@ -6,10 +6,13 @@ object enters a small buffer region around the viewfinder's frame. The logger sa
 images as .npy files and writes a jsonl file containing metadata about the object
 and pose for each image.
 
+This module currently requires a pretrained model.
+
 The primary use case for this module is to generate object images used for training
 and testing traditional models (e.g., vision transformers).
 
 """
+
 import copy
 import json
 import logging
@@ -343,9 +346,9 @@ view_finder_base_randrot["experiment_args"].n_eval_epochs = 14
 view_finder_base_randrot["logging_config"].output_dir = os.path.join(
     project_dir, "view_finder_base_randrot"
 )
-view_finder_base_randrot["eval_dataloader_args"].object_init_sampler = (
-    RandomRotationObjectInitializer()
-)
+view_finder_base_randrot[
+    "eval_dataloader_args"
+].object_init_sampler = RandomRotationObjectInitializer()
 
 # ----------------------------------------------------------------------------
 # 224 x 224


### PR DESCRIPTION
This PR adds configs used for generating RGBD images of objects that are "well-framed" (see below). This is done through the addition of `experiments/configs/view_finder_images.py`. 

> This module contains configs, a logger, and a motor policy for generating RGBD images
> of objects taken from the viewfinder. The motor policy ensures that the whole
> object fits within the view-finder's frame. It does this by moving forward until the
> object enters a small buffer region around the viewfinder's frame. The logger saves the
> images as .npy files and writes a jsonl file containing metadata about the object
> and pose for each image.

The configs added here are used to generate images for training and testing a vision transformer.