### PR TITLE
Further config tweaks

### DIFF
--- a/dmc/README.md
+++ b/dmc/README.md
@@ -8,4 +8,4 @@ Configs to train models and run experiments are in the `configs` directory.
 
 ## Reproducting Figures from the Paper
 
-Analaysis scripts to generate the figures are in the `scripts` directory. The data can either be generated via `configs`, or downloaded directly via `link-to-be-confimed`.
+Analaysis scripts to generate the figures are in the `scripts` directory. The data for figures can either be generated via `configs`, or you can directly download the pre-trained models at `link-to-be-confirmed` and the raw results from experiments at `link-to-be-confirmed`.

--- a/dmc/README.md
+++ b/dmc/README.md
@@ -4,4 +4,8 @@ This repository contains the code for the experiments in the paper "Demonstratin
 
 ## Running the Experiments
 
+Configs to train models and run experiments are in the `configs` directory.
+
 ## Reproducting Figures from the Paper
+
+Analaysis scripts to generate the figures are in the `scripts` directory. The data can either be generated via `configs`, or downloaded directly via `link-to-be-confimed`.

--- a/dmc/configs/README.md
+++ b/dmc/configs/README.md
@@ -46,10 +46,6 @@ This means performance is evaluated with:
 
 The main output measure is accuracy and rotation error as a function of number of LMs.
 
-**TODO:**
-- Config builders for arbitrary numbers of LMs are not currently included in `dmc_eval_experiments.py`.
-- Comparable configs should be used to generate views for evaluated rotations to pass to ViT model for comparison.
-
 ## Figure 5: Rapid Inference with Model-Based Policies
 
 Consists of 3 experiments:
@@ -70,9 +66,6 @@ This means performance is evaluated with:
 - Varying levels of hypothesis-testing
 
 The main output measure is accuracy and rotation error as a function of hypothesis-testing policy.
-
-**TODO:**
-- These configs need to be specified.
 
 ## Figure 6: Rapid Learning
 
@@ -101,10 +94,6 @@ The main output measure is accuracy and rotation error as a function of training
   1. First 6 rotations = cube faces
   2. Next 8 rotations = cube corners
   3. Remaining = random rotations (as otherwise introduces redundancy)
-
-**TODO:**
-- Configs need to be specified
-- Comparable configs needed for ViT model comparison
 
 ## Figure 7: Computationally Efficient Learning and Inference
 
@@ -143,10 +132,6 @@ The main output measure is accuracy and FLOPs as a function of x-percent thresho
 
 The main output measure is FLOPs as a function of whether the ViT or Monty is training.
 
-**TODO:**
-- Configs need specification (including `dist_agent_77obj_1rot_trained` in `dmc_pretrain_experiments.py`)
-- Comparable config needed to generate views corresponding to the 5 random, evaluated rotations, which can then be passed to the ViT model(s) for comparison.
-
 ## Figure 8: Multi-Modal Transfer
 
 Consists of 4 experiments:
@@ -181,6 +166,3 @@ The main output measure is a dendrogram showing evidence score clustering for th
 **Notes:**
 - Although evaluating on 10 objects, the model is trained on 77 objects.
 - We need to run this experiment with SELECTIVE logging on so we get the evidence values to analyze.
-
-**TODO:**
-- Config needs specification, including training config for similar objects in `dmc_pretrain_experiments.py`.

--- a/dmc/configs/README.md
+++ b/dmc/configs/README.md
@@ -38,34 +38,34 @@ Consists of 5 experiments:
 - `dist_agent_8lm_randrot_noise`
 - `dist_agent_16lm_randrot_noise`
 
+With two variations, either
+- Half the number of LMs must match; this will tend to increase accuracy, but with a smaller improvement in convergence as a function of matching steps.
+  - `min_lms_match=int(num_lms/2)`
+- Or, the minimum number of LMs that must match is 2; this will tend to increase convergence very quickly, but with a smaller/minimal improvement in accuracy.
+  - `min_lms_match=min(num_lms, 2)`
+
 This means performance is evaluated with:
 - 77 objects
 - Goal-state-driven/hypothesis-testing policy active
 - Sensor noise and 5 random rotations
 - Voting over 1, 2, 4, 8, or 16 LMs
 
-The main output measure is accuracy and rotation error as a function of number of LMs.
+The main output measure is accuracy and rotation error as a function of number of LMs. The two variations show that accuracy and convergence speed can be traded off against each other.
 
-## Figure 5: Rapid Inference with Model-Based Policies
+## Figure 5: Rapid Inference with Model-Free and Model-Based Policies
 
 Consists of 3 experiments:
-- `dist_agent_1lm_randrot_noise_nohyp` - No hypothesis-testing
-- `dist_agent_1lm_randrot_noise_moderatehyp` - Occasional hypothesis-testing
-  - Should specify:
-    - elapsed_steps_factor=20
-    - min_post_goal_success_steps=10
-- `dist_agent_1lm_randrot_noise` - Default, frequent hypothesis-testing
-  - Should specify:
-    - elapsed_steps_factor=10
-    - min_post_goal_success_steps=5
+- `dist_agent_1lm_randrot_noise_nohyp` - No hypothesis-testing, and random-walk policy
+- `surf_agent_1lm_randrot_noise_nohyp` - Model-free policy to explore surface
+- `surf_agent_1lm_randrot_noise` - Default, i.e. model-free and model-based policies
 
 This means performance is evaluated with:
 - 77 objects
 - Sensor noise and 5 random rotations
 - No voting
-- Varying levels of hypothesis-testing
+- Varying policies; the surface agent (i.e. with color etc) gets the same kind of sensory information as the distant agent, and so differs only in its model-free policy that encourages rapid exploration of the surface of the object. We can make it clear in the paper that there is nothing preventing the distant agent from also having model-free and model-based policies.
 
-The main output measure is accuracy and rotation error as a function of hypothesis-testing policy.
+The main output measure is accuracy and rotation error as a function of the policy used.
 
 ## Figure 6: Rapid Learning
 

--- a/dmc/configs/fig4_rapid_inference_with_voting.py
+++ b/dmc/configs/fig4_rapid_inference_with_voting.py
@@ -24,6 +24,8 @@ All of these experiments use:
 
 """
 
+from copy import deepcopy
+
 from tbp.monty.frameworks.config_utils.config_args import (
     ParallelEvidenceLMLoggingConfig,
     make_multi_lm_monty_config,
@@ -187,16 +189,48 @@ dist_agent_16lm = dict(
         object_init_sampler=PredefinedObjectInitializer(),
     ),
 )
+
+# ==== Variants where min_lms_match=int(num_lms/2) ====
 dist_agent_1lm_randrot_noise = make_randrot_noise_variant(dist_agent_1lm)
-dist_agent_2lm_randrot_noise = make_randrot_noise_variant(dist_agent_2lm)
-dist_agent_4lm_randrot_noise = make_randrot_noise_variant(dist_agent_4lm)
-dist_agent_8lm_randrot_noise = make_randrot_noise_variant(dist_agent_8lm)
-dist_agent_16lm_randrot_noise = make_randrot_noise_variant(dist_agent_16lm)
+dist_agent_2lm_half_lms_match_randrot_noise = make_randrot_noise_variant(dist_agent_2lm)
+dist_agent_4lm_half_lms_match_randrot_noise = make_randrot_noise_variant(dist_agent_4lm)
+dist_agent_8lm_half_lms_match_randrot_noise = make_randrot_noise_variant(dist_agent_8lm)
+dist_agent_16lm_half_lms_match_randrot_noise = make_randrot_noise_variant(
+    dist_agent_16lm
+)
+
+# ==== Variants where min_lms_match=min(num_lms, 2) ====
+dist_agent_2lm_fixed_min_lms_match = deepcopy(dist_agent_2lm)
+dist_agent_2lm_fixed_min_lms_match["experiment_args"].min_lms_match = 2
+dist_agent_4lm_fixed_min_lms_match = deepcopy(dist_agent_4lm)
+dist_agent_4lm_fixed_min_lms_match["experiment_args"].min_lms_match = 2
+dist_agent_8lm_fixed_min_lms_match = deepcopy(dist_agent_8lm)
+dist_agent_8lm_fixed_min_lms_match["experiment_args"].min_lms_match = 2
+dist_agent_16lm_fixed_min_lms_match = deepcopy(dist_agent_16lm)
+dist_agent_16lm_fixed_min_lms_match["experiment_args"].min_lms_match = 2
+
+# Make random-noise versions
+dist_agent_2lm_fixed_min_lms_match_randrot_noise = make_randrot_noise_variant(
+    dist_agent_2lm_fixed_min_lms_match
+)
+dist_agent_4lm_fixed_min_lms_match_randrot_noise = make_randrot_noise_variant(
+    dist_agent_4lm_fixed_min_lms_match
+)
+dist_agent_8lm_fixed_min_lms_match_randrot_noise = make_randrot_noise_variant(
+    dist_agent_8lm_fixed_min_lms_match
+)
+dist_agent_16lm_fixed_min_lms_match_randrot_noise = make_randrot_noise_variant(
+    dist_agent_16lm_fixed_min_lms_match
+)
 
 CONFIGS = {
     "dist_agent_1lm_randrot_noise": dist_agent_1lm_randrot_noise,
-    "dist_agent_2lm_randrot_noise": dist_agent_2lm_randrot_noise,
-    "dist_agent_4lm_randrot_noise": dist_agent_4lm_randrot_noise,
-    "dist_agent_8lm_randrot_noise": dist_agent_8lm_randrot_noise,
-    "dist_agent_16lm_randrot_noise": dist_agent_16lm_randrot_noise,
+    "dist_agent_2lm_half_lms_match_randrot_noise": dist_agent_2lm_half_lms_match_randrot_noise,
+    "dist_agent_4lm_half_lms_match_randrot_noise": dist_agent_4lm_half_lms_match_randrot_noise,
+    "dist_agent_8lm_half_lms_match_randrot_noise": dist_agent_8lm_half_lms_match_randrot_noise,
+    "dist_agent_16lm_half_lms_match_randrot_noise": dist_agent_16lm_half_lms_match_randrot_noise,
+    "dist_agent_2lm_fixed_min_lms_match_randrot_noise": dist_agent_2lm_fixed_min_lms_match_randrot_noise,
+    "dist_agent_4lm_fixed_min_lms_match_randrot_noise": dist_agent_4lm_fixed_min_lms_match_randrot_noise,
+    "dist_agent_8lm_fixed_min_lms_match_randrot_noise": dist_agent_8lm_fixed_min_lms_match_randrot_noise,
+    "dist_agent_16lm_fixed_min_lms_match_randrot_noise": dist_agent_16lm_fixed_min_lms_match_randrot_noise,
 }


### PR DESCRIPTION
This makes a few small adjustments to the DMC configs, per some discussions Scott and I had on Friday. Notably
- Splits up voting into two variants, one where the minimum number of matching LMs scales with the total number (the experiments that Scott has already run), and one where it is fixed. It should be interesting to show both of these in Figure 4 as they each have their advantages. In particular, the former showed improvements to accuracy, but while the number of steps to convergence decreased, it was not monotonic. We expect with the latter, it should be strictly monotonic.
- Changing the main variation in Figure 5 to be the type of policy, rather than varying the hypothesis-driven hyperparameters. This should have a more pronounced effect, and is also a bigger-picture/more interesting aspect of policy to examine than just varying a hyperparameter. 

I have updated the actual configures for Figure 4, but I haven't done so for Figure 5 as I wasn't sure @scottcanoe what your preferred approach for surface agents configs is and it sounded like you had already defined these somewhere on your branch. 