### PR TITLE
refactor: update to import habitat configs from new module

### DIFF
--- a/experiments/configs/base.py
+++ b/experiments/configs/base.py
@@ -20,11 +20,13 @@ from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     EnvironmentDataLoaderPerObjectEvalArgs,
     EnvironmentDataLoaderPerObjectTrainArgs,
     ExperimentArgs,
-    SimpleMountHabitatDatasetArgs,
-    SinglePTZHabitatDatasetArgs,
 )
 from tbp.monty.frameworks.environments import embodied_data as ED
 from tbp.monty.frameworks.experiments import MontyExperiment
+from tbp.monty.simulators.habitat.configs import (
+    SimpleMountHabitatDatasetArgs,
+    SinglePTZHabitatDatasetArgs,
+)
 
 experiment_args = ExperimentArgs()
 debug_experiment_args = DebugExperimentArgs()

--- a/experiments/configs/data_generators.py
+++ b/experiments/configs/data_generators.py
@@ -23,7 +23,6 @@ from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     DebugExperimentArgs,
     EnvironmentDataloaderPerObjectArgs,
     ExperimentArgs,
-    PatchViewFinderMountHabitatDatasetArgs,
     PredefinedObjectInitializer,
     get_env_dataloader_per_object_by_idx,
     get_object_names_by_idx,
@@ -34,6 +33,7 @@ from tbp.monty.frameworks.experiments import (
 )
 from tbp.monty.frameworks.models.displacement_matching import DisplacementGraphLM
 from tbp.monty.frameworks.models.feature_location_matching import FeatureGraphLM
+from tbp.monty.simulators.habitat.configs import PatchViewFinderMountHabitatDatasetArgs
 
 from .graph_experiments import debug_camera_patch_multi_object
 

--- a/experiments/configs/evidence_evaluation.py
+++ b/experiments/configs/evidence_evaluation.py
@@ -23,10 +23,7 @@ from tbp.monty.frameworks.config_utils.config_args import (
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     EnvironmentDataloaderPerObjectArgs,
     EvalExperimentArgs,
-    FiveLMMountHabitatDatasetArgs,
-    PatchViewFinderMountHabitatDatasetArgs,
     PredefinedObjectInitializer,
-    SurfaceViewFinderMountHabitatDatasetArgs,
     get_env_dataloader_per_object_by_idx,
     get_object_names_by_idx,
 )
@@ -39,6 +36,11 @@ from tbp.monty.frameworks.experiments import (
 from tbp.monty.frameworks.models.evidence_matching import (
     EvidenceGraphLM,
     MontyForEvidenceGraphMatching,
+)
+from tbp.monty.simulators.habitat.configs import (
+    FiveLMMountHabitatDatasetArgs,
+    PatchViewFinderMountHabitatDatasetArgs,
+    SurfaceViewFinderMountHabitatDatasetArgs,
 )
 
 # FOR SUPERVISED PRETRAINING

--- a/experiments/configs/evidence_sdr_evaluation.py
+++ b/experiments/configs/evidence_sdr_evaluation.py
@@ -28,12 +28,8 @@ from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     DebugExperimentArgs,
     EnvironmentDataloaderPerObjectArgs,
     EvalExperimentArgs,
-    FiveLMMountHabitatDatasetArgs,
-    PatchViewFinderMountHabitatDatasetArgs,
     PredefinedObjectInitializer,
     RandomRotationObjectInitializer,
-    SurfaceViewFinderMountHabitatDatasetArgs,
-    TwoLMStackedDistantMountHabitatDatasetArgs,
     get_env_dataloader_per_object_by_idx,
     get_object_names_by_idx,
 )
@@ -51,6 +47,12 @@ from tbp.monty.frameworks.models.goal_state_generation import (
 from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     FeatureChangeSM,
+)
+from tbp.monty.simulators.habitat.configs import (
+    FiveLMMountHabitatDatasetArgs,
+    PatchViewFinderMountHabitatDatasetArgs,
+    SurfaceViewFinderMountHabitatDatasetArgs,
+    TwoLMStackedDistantMountHabitatDatasetArgs,
 )
 
 """

--- a/experiments/configs/feature_matching_evaluation.py
+++ b/experiments/configs/feature_matching_evaluation.py
@@ -28,10 +28,7 @@ from tbp.monty.frameworks.config_utils.config_args import (
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     EnvironmentDataloaderPerObjectArgs,
     EvalExperimentArgs,
-    PatchViewFinderLowResMountHabitatDatasetArgs,
-    PatchViewFinderMountHabitatDatasetArgs,
     PredefinedObjectInitializer,
-    SurfaceViewFinderMountHabitatDatasetArgs,
     get_env_dataloader_per_object_by_idx,
     get_object_names_by_idx,
 )
@@ -40,6 +37,11 @@ from tbp.monty.frameworks.environments.ycb import SHUFFLED_YCB_OBJECTS
 from tbp.monty.frameworks.experiments import MontyObjectRecognitionExperiment
 from tbp.monty.frameworks.models.feature_location_matching import FeatureGraphLM
 from tbp.monty.frameworks.utils.logging_utils import get_reverse_rotation
+from tbp.monty.simulators.habitat.configs import (
+    PatchViewFinderLowResMountHabitatDatasetArgs,
+    PatchViewFinderMountHabitatDatasetArgs,
+    SurfaceViewFinderMountHabitatDatasetArgs,
+)
 
 # FOR SUPERVISED PRETRAINING
 tested_degrees = np.linspace(0, 360, 5)[:-1]  # gives 32 combinations

--- a/experiments/configs/graph_experiments.py
+++ b/experiments/configs/graph_experiments.py
@@ -33,15 +33,9 @@ from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     DebugExperimentArgs,
     EnvironmentDataloaderPerObjectArgs,
     ExperimentArgs,
-    FiveLMMountHabitatDatasetArgs,
-    MultiLMMountHabitatDatasetArgs,
     OmniglotDataloaderArgs,
     OmniglotDatasetArgs,
-    PatchViewFinderMountHabitatDatasetArgs,
-    PatchViewFinderShapenetMountHabitatDatasetArgs,
     PredefinedObjectInitializer,
-    TwoLMStackedDistantMountHabitatDatasetArgs,
-    TwoLMStackedSurfaceMountHabitatDatasetArgs,
     WorldImageDataloaderArgs,
     WorldImageDatasetArgs,
     get_env_dataloader_per_object_by_idx,
@@ -65,6 +59,14 @@ from tbp.monty.frameworks.models.sensor_modules import (
     HabitatDistantPatchSM,
 )
 from tbp.monty.frameworks.utils.logging_utils import get_reverse_rotation
+from tbp.monty.simulators.habitat.configs import (
+    FiveLMMountHabitatDatasetArgs,
+    MultiLMMountHabitatDatasetArgs,
+    PatchViewFinderMountHabitatDatasetArgs,
+    PatchViewFinderShapenetMountHabitatDatasetArgs,
+    TwoLMStackedDistantMountHabitatDatasetArgs,
+    TwoLMStackedSurfaceMountHabitatDatasetArgs,
+)
 
 camera_patch_multi_object = dict(
     experiment_class=MontyObjectRecognitionExperiment,

--- a/experiments/configs/more_pretraining_experiments.py
+++ b/experiments/configs/more_pretraining_experiments.py
@@ -28,13 +28,9 @@ from tbp.monty.frameworks.config_utils.config_args import (
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     EnvironmentDataloaderPerObjectArgs,
     ExperimentArgs,
-    MultiLMMountHabitatDatasetArgs,
-    NoisyPatchViewFinderMountHabitatDatasetArgs,
     OmniglotDataloaderArgs,
     OmniglotDatasetArgs,
-    PatchViewFinderMountHabitatDatasetArgs,
     PredefinedObjectInitializer,
-    SurfaceViewFinderMountHabitatDatasetArgs,
     get_env_dataloader_per_object_by_idx,
     get_object_names_by_idx,
     get_omniglot_train_dataloader,
@@ -55,6 +51,12 @@ from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     HabitatDistantPatchSM,
     HabitatSurfacePatchSM,
+)
+from tbp.monty.simulators.habitat.configs import (
+    MultiLMMountHabitatDatasetArgs,
+    NoisyPatchViewFinderMountHabitatDatasetArgs,
+    PatchViewFinderMountHabitatDatasetArgs,
+    SurfaceViewFinderMountHabitatDatasetArgs,
 )
 
 # --- Further Pretraining Experiments ---

--- a/experiments/configs/policy_experiments.py
+++ b/experiments/configs/policy_experiments.py
@@ -25,11 +25,7 @@ from tbp.monty.frameworks.config_utils.config_args import (
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     EnvironmentDataloaderPerObjectArgs,
     EvalExperimentArgs,
-    NoisyPatchViewFinderMountHabitatDatasetArgs,
-    NoisySurfaceViewFinderMountHabitatDatasetArgs,
-    PatchViewFinderMountHabitatDatasetArgs,
     PredefinedObjectInitializer,
-    SurfaceViewFinderMountHabitatDatasetArgs,
     get_env_dataloader_per_object_by_idx,
     get_object_names_by_idx,
 )
@@ -43,6 +39,12 @@ from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     FeatureChangeSM,
     HabitatDistantPatchSM,
+)
+from tbp.monty.simulators.habitat.configs import (
+    NoisyPatchViewFinderMountHabitatDatasetArgs,
+    NoisySurfaceViewFinderMountHabitatDatasetArgs,
+    PatchViewFinderMountHabitatDatasetArgs,
+    SurfaceViewFinderMountHabitatDatasetArgs,
 )
 
 """

--- a/experiments/configs/robustness_experiments.py
+++ b/experiments/configs/robustness_experiments.py
@@ -24,12 +24,8 @@ from tbp.monty.frameworks.config_utils.config_args import (
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     EnvironmentDataloaderPerObjectArgs,
     EvalExperimentArgs,
-    FiveLMMountHabitatDatasetArgs,
-    NoisyPatchViewFinderMountHabitatDatasetArgs,
-    PatchViewFinderMountHabitatDatasetArgs,
     PredefinedObjectInitializer,
     RandomRotationObjectInitializer,
-    SurfaceViewFinderMountHabitatDatasetArgs,
     get_env_dataloader_per_object_by_idx,
     get_object_names_by_idx,
 )
@@ -43,6 +39,12 @@ from tbp.monty.frameworks.models.feature_location_matching import FeatureGraphLM
 from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     HabitatDistantPatchSM,
+)
+from tbp.monty.simulators.habitat.configs import (
+    FiveLMMountHabitatDatasetArgs,
+    NoisyPatchViewFinderMountHabitatDatasetArgs,
+    PatchViewFinderMountHabitatDatasetArgs,
+    SurfaceViewFinderMountHabitatDatasetArgs,
 )
 
 tested_degrees = np.linspace(0, 360, 5)[:-1]  # gives 32 combinations

--- a/experiments/configs/view_finder_images.py
+++ b/experiments/configs/view_finder_images.py
@@ -36,7 +36,6 @@ from tbp.monty.frameworks.config_utils.config_args import (
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     EnvironmentDataloaderPerObjectArgs,
     EvalExperimentArgs,
-    PatchViewFinderMountHabitatDatasetArgs,
     PredefinedObjectInitializer,
     RandomRotationObjectInitializer,
 )
@@ -52,6 +51,7 @@ from tbp.monty.frameworks.models.motor_policies import (
     InformedPolicy,
     get_perc_on_obj_semantic,
 )
+from tbp.monty.simulators.habitat.configs import PatchViewFinderMountHabitatDatasetArgs
 
 
 class ViewFinderRGBDHandler(MontyHandler):


### PR DESCRIPTION
HabitatSim-dependent configurations moved: https://github.com/thousandbrainsproject/tbp.monty/commit/2ad3d1182669eb0c27cf86b5654fc371f61592d2 . This pull request updates imports to import from their new locations.