### PR TITLE
refactor!: upgrade /experiments motor system configs for latest tbp.monty==0.3.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,4 +25,4 @@ channels:
   - thousandbrainsproject
 
 dependencies:
-  - thousandbrainsproject::tbp.monty
+  - thousandbrainsproject::tbp.monty>=0.3.0

--- a/experiments/configs/graph_experiments.py
+++ b/experiments/configs/graph_experiments.py
@@ -17,6 +17,7 @@ from typing import Callable, Dict, Union
 import numpy as np
 from tbp.monty.frameworks.actions.action_samplers import ConstantSampler
 from tbp.monty.frameworks.config_utils.config_args import (
+    Dataclass,
     FiveLMMontyConfig,
     InformedPolicy,
     LoggingConfig,
@@ -54,6 +55,7 @@ from tbp.monty.frameworks.models.evidence_matching import (
     MontyForEvidenceGraphMatching,
 )
 from tbp.monty.frameworks.models.feature_location_matching import FeatureGraphLM
+from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     HabitatDistantPatchSM,
@@ -694,13 +696,16 @@ two_lm_surface_heterarchy_all_objects.update(
 class MotorSystemConfigFixed:
     """A motor system with a fixed action sequence that gets repeated."""
 
-    motor_system_class: Callable = field(default=InformedPolicy)
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=5.0,
-            file_name=Path(__file__).parent / "resources/fixed_test_actions.jsonl",
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=5.0,
+                file_name=Path(__file__).parent / "resources/fixed_test_actions.jsonl",
+            ),
         )
     )
 

--- a/experiments/configs/more_pretraining_experiments.py
+++ b/experiments/configs/more_pretraining_experiments.py
@@ -47,6 +47,7 @@ from tbp.monty.frameworks.experiments import (
     MontySupervisedObjectPretrainingExperiment,
 )
 from tbp.monty.frameworks.models.displacement_matching import DisplacementGraphLM
+from tbp.monty.frameworks.models.motor_policies import NaiveScanPolicy
 from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     HabitatDistantPatchSM,
@@ -126,7 +127,10 @@ supervised_pre_training_base = dict(
             )
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=5)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=5),
+            )
         ),  # use spiral policy for more even object coverage during learning
     ),
     dataset_class=ED.EnvironmentDataset,
@@ -159,7 +163,10 @@ supervised_pre_training_storeall.update(
             )
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=5)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=5),
+            )
         ),  # use spiral policy for more even object coverage during learning
     ),
 )
@@ -179,7 +186,10 @@ supervised_pre_training_stepsize3.update(
             )
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=3)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=3),
+            )
         ),
     ),
 )
@@ -202,7 +212,10 @@ supervised_pre_training_stepsize3_storeall.update(
             )
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=3)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=3),
+            )
         ),
     ),
 )
@@ -222,7 +235,10 @@ supervised_pre_training_stepsize6.update(
             )
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=6)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=6),
+            )
         ),
     ),
 )
@@ -245,7 +261,10 @@ supervised_pre_training_stepsize6_storeall.update(
             )
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=6)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=6),
+            )
         ),
     ),
 )
@@ -262,7 +281,10 @@ supervised_pre_training_feature_change_s3.update(
     monty_config=PatchAndViewFeatureChangeConfig(
         monty_args=MontyArgs(num_exploratory_steps=1000),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=3)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=3),
+            )
         ),
     ),
 )
@@ -372,7 +394,10 @@ supervised_pre_training_location_noise002.update(
             sensor_module_1=view_finder_config,
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=5)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=5),
+            )
         ),  # use spiral policy for more even object coverage during learning
     ),
 )
@@ -406,7 +431,10 @@ supervised_pre_training_location_noise005.update(
             sensor_module_1=view_finder_config,
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=5)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=5),
+            )
         ),  # use spiral policy for more even object coverage during learning
     ),
 )
@@ -440,7 +468,10 @@ supervised_pre_training_location_noise001.update(
             sensor_module_1=view_finder_config,
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=5)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=5),
+            )
         ),  # use spiral policy for more even object coverage during learning
     ),
 )
@@ -657,7 +688,10 @@ supervised_pre_training_2lms.update(
             ),
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=5)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=5),
+            )
         ),
     ),
     dataset_args=MultiLMMountHabitatDatasetArgs(),

--- a/experiments/configs/view_finder_images.py
+++ b/experiments/configs/view_finder_images.py
@@ -20,7 +20,6 @@ import os
 import shutil
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 from tbp.monty.frameworks.actions.action_samplers import ConstantSampler
 from tbp.monty.frameworks.actions.actions import (
@@ -51,6 +50,7 @@ from tbp.monty.frameworks.models.motor_policies import (
     InformedPolicy,
     get_perc_on_obj_semantic,
 )
+from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.simulators.habitat.configs import PatchViewFinderMountHabitatDatasetArgs
 
 
@@ -246,15 +246,18 @@ Configs
 """
 
 motor_system_config = MotorSystemConfigInformedNoTransStepS20(
-    motor_system_class=FramedObjectPolicy,
-    motor_system_args=make_informed_policy_config(
-        action_space_type="distant_agent_no_translation",
-        action_sampler_class=ConstantSampler,
-        rotation_degrees=5.0,
-        use_goal_state_driven_actions=False,
-        switch_frequency=1.0,
-        good_view_percentage=0.5,  # Make sure we define the required
-        desired_object_distance=0.2,
+    motor_system_class=MotorSystem,
+    motor_system_args=dict(
+        policy_class=FramedObjectPolicy,
+        policy_args=make_informed_policy_config(
+            action_space_type="distant_agent_no_translation",
+            action_sampler_class=ConstantSampler,
+            rotation_degrees=5.0,
+            use_goal_state_driven_actions=False,
+            switch_frequency=1.0,
+            good_view_percentage=0.5,  # Make sure we define the required
+            desired_object_distance=0.2,
+        ),
     ),
 )
 


### PR DESCRIPTION
`tbp.monty==0.3.0` introduces a breaking change to the motor system configuration (https://github.com/thousandbrainsproject/tbp.monty/pull/241). This pull request updates the `/experiments` motor system configurations to accommodate the change.