### PR TITLE
Add deprecation note

### DIFF
--- a/dmc/README.md
+++ b/dmc/README.md
@@ -1,4 +1,4 @@
-# Demonstrating Monty Capabilities Experiments (DEPRICATED)
+# Demonstrating Monty Capabilities Experiments (DEPRECATED)
 
 ==== DEPRICATION ====
 

--- a/dmc/README.md
+++ b/dmc/README.md
@@ -1,4 +1,10 @@
-# Demonstrating Monty Capabilities Experiments
+# Demonstrating Monty Capabilities Experiments (DEPRICATED)
+
+==== DEPRICATION ====
+
+This directory contains intitial configs and scripts for early work on the "DMC" paper. It has been depricated and anyone interested in replicating the results of our paper, "Thousand-Brains Systems: Sensorimotor Intelligence for Rapid, Robust Learning and Inference", should refer to the repository here https://github.com/thousandbrainsproject/tbp.tbs_sensorimotor_intelligence
+
+=====================
 
 This repository contains the code for the experiments in the paper "Demonstrating Monty Capabilities".
 

--- a/dmc/README.md
+++ b/dmc/README.md
@@ -2,7 +2,7 @@
 
 ==== DEPRECATION ====
 
-This directory contains intitial configs and scripts for early work on the "DMC" paper. It has been depricated and anyone interested in replicating the results of our paper, "Thousand-Brains Systems: Sensorimotor Intelligence for Rapid, Robust Learning and Inference", should refer to the repository here https://github.com/thousandbrainsproject/tbp.tbs_sensorimotor_intelligence
+This directory contains intitial configs and scripts for early work on the "DMC" paper. It has been deprecated and anyone interested in replicating the results of our paper, "Thousand-Brains Systems: Sensorimotor Intelligence for Rapid, Robust Learning and Inference", should refer to the repository here https://github.com/thousandbrainsproject/tbp.tbs_sensorimotor_intelligence
 
 =====================
 

--- a/dmc/README.md
+++ b/dmc/README.md
@@ -1,6 +1,6 @@
 # Demonstrating Monty Capabilities Experiments (DEPRECATED)
 
-==== DEPRICATION ====
+==== DEPRECATION ====
 
 This directory contains intitial configs and scripts for early work on the "DMC" paper. It has been depricated and anyone interested in replicating the results of our paper, "Thousand-Brains Systems: Sensorimotor Intelligence for Rapid, Robust Learning and Inference", should refer to the repository here https://github.com/thousandbrainsproject/tbp.tbs_sensorimotor_intelligence
 


### PR DESCRIPTION
Add a note to make it clear that the old DMC folder is not relevant, instead links to the TBS repository.